### PR TITLE
RealIp is not a module but a class

### DIFF
--- a/lib/real_ip/version.rb
+++ b/lib/real_ip/version.rb
@@ -1,3 +1,3 @@
-module RealIp
+class RealIp
   VERSION = "0.1.0"
 end


### PR DESCRIPTION
I'm still not sure but sometimes bundler (or rubygems?) puts non-stub gemspec file and then this can raise `TypeError: RealIp is not a module`.

Usually, loaded `gemspec` file is a stub.

```rb
# -*- encoding: utf-8 -*-
# stub: real_ip 0.1.0 ruby lib

Gem::Specification.new do |s|
  s.name = "real_ip".freeze
  s.version = "0.1.0"

  s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
  s.metadata = { "allowed_push_host" => "TODO: Set to 'http://mygemserver.com'" } if s.respond_to? :metadata=
  s.require_paths = ["lib".freeze]
...
```

And non-stub `gemspec` is identical this one:
https://github.com/quipper/real_ip/tree/e1b983fbe45ae87ecb23aecfb88390936b85baab

When the file is loaded, it raises the error because it requires `real_ip/version`.

```rb
# coding: utf-8
lib = File.expand_path('../lib', __FILE__)
$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
require 'real_ip/version'
```